### PR TITLE
Use readonly FileStream to open image files.

### DIFF
--- a/src/BlurHashSharp.SkiaSharp/BlurHashEncoder.cs
+++ b/src/BlurHashSharp.SkiaSharp/BlurHashEncoder.cs
@@ -44,7 +44,8 @@ namespace BlurHashSharp.SkiaSharp
         /// <returns>BlurHash representation of the image.</returns>
         public static string Encode(int xComponent, int yComponent, string filename)
         {
-            using (SKCodec codec = SKCodec.Create(filename))
+            using var fileStream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using (SKCodec codec = SKCodec.Create(fileStream))
             {
                 var newInfo = new SKImageInfo()
                 {
@@ -73,7 +74,8 @@ namespace BlurHashSharp.SkiaSharp
         /// <returns>BlurHash representation of the image.</returns>
         public static string Encode(int xComponent, int yComponent, string filename, int maxWidth, int maxHeight)
         {
-            using (SKCodec codec = SKCodec.Create(filename))
+            using var fileStream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using (SKCodec codec = SKCodec.Create(fileStream))
             {
                 var width = codec.Info.Width;
                 var height = codec.Info.Height;


### PR DESCRIPTION
The `SKCodec.Create(String)` method will use libskia's native method to open the file that does not allow file sharing, which will block all subsequent open requests even if the subsequent open is read-only.

Use a managed read-only stream as a workaround.

Related: https://github.com/jellyfin/jellyfin/issues/3687